### PR TITLE
[fix] Add `nav` to SongsPage object

### DIFF
--- a/js/pages/songs.js
+++ b/js/pages/songs.js
@@ -12,9 +12,8 @@ import {SongDetailPage} from './song-detail';
 export class SongsPage {
   constructor(app: IonicApp, nav: NavController) {
     this.name = 'Max';
-
+    this.nav = nav;
     this.app = app;
-
 
     this.songs = [
       { title: 'Linoleum', artist: 'NOFX' },


### PR DESCRIPTION
`SongsPage.openSong()` was erroring when attempting to reference `this.nav` since the `constructor` did not define it.
