### PR TITLE
[docs] correct port to 8100

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Then `gulp watch` to transpile the app's es6 code down to es5, spin up a local d
 $ gulp watch
 ```
 
-Then navigate to `http://localhost:8000` to check it out!
+Then navigate to `http://localhost:8100` to check it out!


### PR DESCRIPTION
Port was indicated to be 8000 rather than the value specified in the gulpfile of 8100. Fixes https://github.com/driftyco/ionic2-starter/issues/1
